### PR TITLE
ruby: only use one call to rand

### DIFF
--- a/ruby/lib/redisrpc.rb
+++ b/ruby/lib/redisrpc.rb
@@ -84,10 +84,10 @@ module RedisRPC
                 raise RemoteException, 'Malformed RPC Response message: ' + rpc_response
             end
             return rpc_response['return_value']
-        end 
+        end
 
-        def rand_string(size=8, charset=%w{ 1 2 3 4 5 6 7 8 9 0 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z})
-            return (0...size).map{ charset.to_a[rand(charset.size)] }.join
+        def rand_string(size=8)
+            return rand(36**size).to_s(36).upcase.rjust(size,'0')
         end
 
         def respond_to?(sym)


### PR DESCRIPTION
replaces the `rand_string` method with one that is a little less versatile (always contains characters that match `/[0-9A-Z]/`) but 10x faster with lower memory allocation and a single call to `rand()` as opposed to one per character. 

Since we're not calling any args on this, it should be an adequate replacement, although it does support the size arg should it be needed.
