### PR TITLE
Don't flush queue on RedisRPC::Server#run

### DIFF
--- a/ruby/lib/redisrpc.rb
+++ b/ruby/lib/redisrpc.rb
@@ -106,8 +106,6 @@ module RedisRPC
         end
 
         def run
-            # Flush the message queue.
-            @redis_server.del @message_queue
             loop do
                 message_queue, message = @redis_server.blpop @message_queue, 0
                 if $DEBUG
@@ -132,6 +130,14 @@ module RedisRPC
             end
         end
 
+        def run!
+            flush_queue!
+            run
+        end
+
+        def flush_queue!
+            @redis_server.del @message_queue
+        end
     end
 
 


### PR DESCRIPTION
In our environment we have multiple `RedisRPC::Server` instances running to serve up multiple clients. Having each flush the queue before starting is a Very Bad Thing and causes us to lose requests.

I added `RedisRPC::Server#flush_queue!`, then added `RedisRPC::Server#run!` which calls it before calling `RedisRPC::Server#run`; the convention in ruby is to add a bang to a method name if it is a destructive variant, which this is.
