### PR TITLE
use multi_json gem

### DIFF
--- a/ruby/lib/redisrpc.rb
+++ b/ruby/lib/redisrpc.rb
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'json'
+require 'multi_json'
 
 require 'redis'
 
@@ -59,7 +59,7 @@ module RedisRPC
             function_call = {'name' => sym.to_s, 'args' => args}
             response_queue = @message_queue + ':rpc:' + rand_string
             rpc_request = {'function_call' => function_call, 'response_queue' => response_queue}
-            message = JSON.generate rpc_request
+            message = MultiJson.dump rpc_request
             if $DEBUG
                 $stderr.puts 'RPC Request: ' + message
             end
@@ -75,7 +75,7 @@ module RedisRPC
                 end
                 $stderr.puts 'RPC Response: ' + message
             end
-            rpc_response = JSON.parse message
+            rpc_response = MultiJson.load message
             exception = rpc_response['exception']
             if exception != nil
                 raise RemoteException, exception
@@ -114,7 +114,7 @@ module RedisRPC
                     fail 'assertion failed' if message_queue != @message_queue
                     $stderr.puts 'RPC Request: ' + message
                 end
-                rpc_request = JSON.parse(message)
+                rpc_request = MultiJson.load message
                 response_queue = rpc_request['response_queue']
                 function_call = FunctionCall.new(rpc_request['function_call'])
                 code = '@local_object.' + function_call.as_ruby_code
@@ -124,7 +124,7 @@ module RedisRPC
                 rescue => err
                     rpc_response = {'exception' => err}
                 end
-                message = JSON.generate rpc_response
+                message = MultiJson.dump rpc_response
                 if $DEBUG
                     $stderr.puts 'RPC Response: ' + message
                 end

--- a/ruby/redisrpc.gemspec
+++ b/ruby/redisrpc.gemspec
@@ -25,6 +25,7 @@ EOS
 
 Gem::Specification.new do |s|
   s.add_runtime_dependency 'redis', '< 3.0.0'
+  s.add_runtime_dependency 'multi_json', '~>1.3'
   s.author = 'Nathan Farrington'
   s.date = Time.now.strftime('%Y-%m-%d')
   s.description = DESCRIPTION


### PR DESCRIPTION
Use the `multi_json` gem, which finds and uses the fastest available JSON encoder, defaulting to the ruby-core `JSON` only when necessary

You will have merge conflict with this one and #2, but it should be pretty trivial to handle.
