### PR TITLE
Dev/ruby gem cleanup with bundler

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gemspec

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,0 +1,21 @@
+PATH
+  remote: .
+  specs:
+    redisrpc (0.3.4)
+      multi_json (~> 1.3)
+      redis
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    multi_json (1.3.2)
+    rake (0.9.2)
+    redis (2.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  rake
+  redisrpc!

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,0 +1,1 @@
+require "bundler/gem_tasks"

--- a/ruby/lib/redisrpc.rb
+++ b/ruby/lib/redisrpc.rb
@@ -112,7 +112,7 @@ module RedisRPC
                 begin
                     return_value = @local_object.send( function_call.method, *function_call.args )
                     rpc_response = {'return_value' => return_value}
-                rescue => err
+                rescue Object => err
                     rpc_response = {'exception' => err}
                 end
                 message = MultiJson.dump rpc_response

--- a/ruby/redisrpc.gemspec
+++ b/ruby/redisrpc.gemspec
@@ -38,4 +38,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'redis'
   s.add_runtime_dependency 'multi_json', '~>1.3'
+
+  s.add_development_dependency 'bundler'
+  s.add_development_dependency 'rake'
 end

--- a/ruby/redisrpc.gemspec
+++ b/ruby/redisrpc.gemspec
@@ -1,39 +1,41 @@
 # -*- encoding: utf-8 -*-
-
 require File.expand_path('../lib/redisrpc/version', __FILE__)
 
-DESCRIPTION = <<-EOS
-RedisRPC is the easiest to use RPC library in the world. (No small claim!) It
-has implementations in Ruby, PHP, and Python.
-
-Redis is a powerful in-memory data structure server that is useful for building
-fast distributed systems. Redis implements message queue functionality with its
-use of list data structures and the `LPOP`, `BLPOP`, and `RPUSH` commands.
-RedisRPC implements a lightweight RPC mechanism using Redis message queues to
-temporarily hold RPC request and response messages. These messages are encoded
-as JSON strings for portability.
-
-Many other RPC mechanisms are either programming language specific (e.g.
-Java RMI) or require boiler-plate code for explicit typing (e.g. Thrift).
-RedisRPC was designed to be extremely easy to use by eliminating boiler-plate
-code while also being programming language neutral.  High performance was not
-an initial goal of RedisRPC and other RPC libraries are likely to have better
-performance. Instead, RedisRPC has better programmer performance; it lets you
-get something working immediately.
-EOS
-
 Gem::Specification.new do |s|
-  s.add_runtime_dependency 'redis', '< 3.0.0'
-  s.add_runtime_dependency 'multi_json', '~>1.3'
-  s.author = 'Nathan Farrington'
-  s.date = Time.now.strftime('%Y-%m-%d')
-  s.description = DESCRIPTION
-  s.email = 'nfarring@gmail.com'
-  s.has_rdoc = false
-  s.files = ['lib/redisrpc.rb']
-  s.homepage = 'http://github.com/nfarring/redisrpc'
-  s.license = 'GPLv3'
   s.name = 'redisrpc'
-  s.summary = 'Lightweight RPC for Redis'
   s.version = RedisRPC::VERSION
+  s.license = 'GPLv3'
+  s.authors = ['Nathan Farrington']
+  s.email = ['nfarring@gmail.com']
+
+  s.homepage = 'http://github.com/nfarring/redisrpc'
+  s.summary = 'Lightweight RPC for Redis'
+  s.description = <<-DESCRIPTION
+    RedisRPC is the easiest to use RPC library in the world. (No small claim!) It
+    has implementations in Ruby, PHP, and Python.
+
+    Redis is a powerful in-memory data structure server that is useful for building
+    fast distributed systems. Redis implements message queue functionality with its
+    use of list data structures and the `LPOP`, `BLPOP`, and `RPUSH` commands.
+    RedisRPC implements a lightweight RPC mechanism using Redis message queues to
+    temporarily hold RPC request and response messages. These messages are encoded
+    as JSON strings for portability.
+
+    Many other RPC mechanisms are either programming language specific (e.g.
+    Java RMI) or require boiler-plate code for explicit typing (e.g. Thrift).
+    RedisRPC was designed to be extremely easy to use by eliminating boiler-plate
+    code while also being programming language neutral.  High performance was not
+    an initial goal of RedisRPC and other RPC libraries are likely to have better
+    performance. Instead, RedisRPC has better programmer performance; it lets you
+    get something working immediately.
+  DESCRIPTION
+  s.has_rdoc = false
+  
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.require_paths = ["lib"]
+
+  s.add_runtime_dependency 'redis'
+  s.add_runtime_dependency 'multi_json', '~>1.3'
 end


### PR DESCRIPTION
- a34665e1: in which I failed to isolate an unrelated commit into its own pull-request, the message is self-explanitory. Implicitly only `StandardError` (and its sub-classes) is caught; let's be explicit and catch _everything_ instead because something getting by here can be bad.
- 3d6906b0: reorganize the gemspec to be the format most gem contributors would expect. 100% of the original content is still there, but we avoid using the un-namespaced constant `DESCRIPTION`.
- 55a3950c: Use Bundler for gem/dependency management and add the associated rake tasks. This is a pre-requisite for future code, in which I'll use bundler to manage the _loading_ of gems in test/spec.
