### PR TITLE
Dev/ruby rspec

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -8,9 +8,18 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    diff-lcs (1.1.3)
     multi_json (1.3.2)
     rake (0.9.2)
     redis (2.2.2)
+    rspec (2.9.0)
+      rspec-core (~> 2.9.0)
+      rspec-expectations (~> 2.9.0)
+      rspec-mocks (~> 2.9.0)
+    rspec-core (2.9.0)
+    rspec-expectations (2.9.1)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.9.0)
 
 PLATFORMS
   ruby
@@ -19,3 +28,4 @@ DEPENDENCIES
   bundler
   rake
   redisrpc!
+  rspec

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,1 +1,7 @@
 require "bundler/gem_tasks"
+
+require 'rspec/core'
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = FileList['spec/**/*.spec.rb']
+end

--- a/ruby/examples/calc.rb
+++ b/ruby/examples/calc.rb
@@ -1,5 +1,6 @@
 class Calculator
     # A simple, mutable calculator used for testing.
+    # referenced explicitly in ../spec/calculator.spec.rb
     
     def initialize
         @acc = 0.0

--- a/ruby/redisrpc.gemspec
+++ b/ruby/redisrpc.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec'
 end

--- a/ruby/spec/calculator.spec.rb
+++ b/ruby/spec/calculator.spec.rb
@@ -1,0 +1,34 @@
+require File.expand_path( '../spec_helper.rb', __FILE__ )
+require File.expand_path( '../../examples/calc.rb', __FILE__ )
+
+describe Calculator do
+  [true,false].each do |over_redisrpc|
+    context "when run ( over_redisrpc ? 'over redisrpc' : 'locally')" do
+
+      if( over_redisrpc )
+        before(:each) do 
+          @server_pid = fork{ RedisRPC::Server.new( Redis.new($REDIS_CONFIG), 'calc', Calculator.new ).run! }
+        end
+        after(:each){ Process.kill 9, @server_pid }
+        let(:calculator){ RedisRPC::Client.new( $REDIS,'calc', 1) }
+      else
+        let(:calculator){ Calculator.new }
+      end
+
+      it 'should calculate' do
+        calculator.val.should == 0.0
+        calculator.add(3).should == 3.0
+        calculator.sub(2).should == 1.0
+        calculator.mul(14).should == 14.0
+        calculator.div(7).should == 2.0
+        calculator.val.should == 2.0
+        calculator.clr.should == 0.0
+        calculator.val.should == 0.0
+      end
+
+      it 'should raise when missing method is called' do
+        expect{ calculator.some_missing_method }.to raise_error
+      end
+    end
+  end
+end

--- a/ruby/spec/redis-test.conf
+++ b/ruby/spec/redis-test.conf
@@ -1,0 +1,3 @@
+port 9736
+daemonize yes
+pidfile redis-test.pid

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -1,0 +1,51 @@
+require 'bundler'
+begin
+  Bundler.require(:default,:development)
+rescue Bundler::BundlerError => e
+  $stderr.puts e.message
+  $stderr.puts "Run `bundle install` to install missing gems"
+  exit e.status_code
+end
+
+RSpec.configure do |config|
+  config.before :suite do
+    raise 'redis-server must be on your path to run this test' if `which redis-server`.empty?
+    $REDIS_CONF_PATH = File.expand_path('../redis-test.conf',__FILE__)
+
+    redis_conf_contents = File.read($REDIS_CONF_PATH)
+    raise "pidfile must be specified in #{$REDIS_CONF_PATH}" unless redis_conf_contents['pidfile'] 
+
+    $REDIS_CONFIG = {
+      :host => 'localhost', 
+      :port => (redis_conf_contents.match(/port ([0-9]+)/)[1].to_i rescue 6379), 
+      :db   => 15 # we'll be flushing regularly; db 15 is traditionally reserved for test
+      }
+
+    $stdout.write "Starting Redis on port #{$REDIS_CONFIG[:port]}... "; $stdout.flush
+    `redis-server #{$REDIS_CONF_PATH}`
+    puts 'Done.'
+    
+    $REDIS = Redis.new($REDIS_CONFIG)
+    begin
+      $REDIS.ping
+    rescue Timeout::Error, Errno::ECONNREFUSED
+      retries ||= 3
+      sleep 1 and retry unless (retries-=1).zero?
+      $stderr.puts 'Could not connect to Redis after 3 tries.'
+      exit
+    end
+  end
+
+  config.around :each do |example|
+    $REDIS.flushdb
+    example.call
+  end
+
+  config.after :suite do
+    pidfile = (File.read($REDIS_CONF_PATH).match(/pidfile (.+)$/)[1].chomp rescue nil)
+    $stdout.write "\nKilling test redis server... "; $stdout.flush
+    Process.kill("KILL", File.read(pidfile).chomp.to_i )
+    File.unlink(pidfile)
+    puts 'Done.'
+  end
+end


### PR DESCRIPTION
_NOTE: This pull-request is based off master_ **_after**_ _#6 has been accepted._
- Implements basic rspec framework for adding specs
- Implements calculator example as `spec/calculator.spec.rb`
- auto-launches & tears-down redis (on an alternate port, selecting an alternate db) around running the spec.
