### PR TITLE
Dev/ruby rewrite

### DIFF
--- a/ruby/lib/redisrpc.rb
+++ b/ruby/lib/redisrpc.rb
@@ -49,6 +49,7 @@ module RedisRPC
       response_queue = @message_queue + ':rpc:' + rand_string
       rpc_request = {'function_call' => function_call, 'response_queue' => response_queue}
       rpc_raw_request = MultiJson.dump rpc_request
+
       # transport
       @redis_server.rpush @message_queue, rpc_raw_request
       message_queue, rpc_raw_response = @redis_server.blpop response_queue, @timeout
@@ -115,7 +116,7 @@ module RedisRPC
         return_value = @local_object.send( function_call['name'].to_sym, *function_call['args'] )
         rpc_response = {'return_value' => return_value}
       rescue Object => err
-        rpc_response = {'exception' => err.to_s}
+        rpc_response = {'exception' => err.to_s, 'backtrace' => err.backtrace}
       end
 
       # response tansport

--- a/ruby/spec/calculator.spec.rb
+++ b/ruby/spec/calculator.spec.rb
@@ -3,13 +3,14 @@ require File.expand_path( '../../examples/calc.rb', __FILE__ )
 
 describe Calculator do
   [true,false].each do |over_redisrpc|
-    context "when run ( over_redisrpc ? 'over redisrpc' : 'locally')" do
+    context "when run #{( over_redisrpc ? 'over redisrpc' : 'locally')}" do
 
       if( over_redisrpc )
+        let(:rpc_server_builder){ lambda{ RedisRPC::Server.new( Redis.new($REDIS_CONFIG), 'calc', Calculator.new ) } }
         before(:each) do 
-          @server_pid = fork{ RedisRPC::Server.new( Redis.new($REDIS_CONFIG), 'calc', Calculator.new ).run! }
+          @server_pid = fork{ rpc_server_builder.call.run }
         end
-        after(:each){ Process.kill 9, @server_pid }
+        after(:each){ Process.kill(9, @server_pid); rpc_server_builder.call.flush_queue! }
         let(:calculator){ RedisRPC::Client.new( $REDIS,'calc', 1) }
       else
         let(:calculator){ Calculator.new }
@@ -27,8 +28,14 @@ describe Calculator do
       end
 
       it 'should raise when missing method is called' do
-        expect{ calculator.some_missing_method }.to raise_error
+        expect{ calculator.a_missing_method }.to raise_error(
+          over_redisrpc ? RedisRPC::RemoteException : NoMethodError
+        )
       end
+
+      it 'should raise timeout when execution expires' do
+        expect{ calculator.send(:sleep,2) }.to raise_error RedisRPC::TimeoutException
+      end if over_redisrpc
     end
   end
 end

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -7,6 +7,11 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 
+def MultiJson.default_adapter
+  :ok_json
+end
+
+
 RSpec.configure do |config|
   config.before :suite do
     raise 'redis-server must be on your path to run this test' if `which redis-server`.empty?


### PR DESCRIPTION
_NOTE: depends on the results of #7 being pulled in_

I'm having to commit to this in fits and starts, mostly because I cannot commit to GPLv3 while on company time (we love open-source, it's just too restrictive a license). Instead of submitting 5 or so pull requests to get to this point, I did an on-my-lunch quick rewrite using your code as a template. If you'd like I'll gladly split this up into smaller chunks, but it might take a week or so. The following is a summary of what was changed functionally:
- Clean up memory leak: expire the `response_queue` in one second. If client is waiting with a `blpop`, it will have already received the value; if client has timed out, it is not waiting and no client will receive this message until a collision of response_queues occurs, at which point it will receive the _wrong_ response & leave its response as a little time-bomb for the next collision.
- Clean up necessitated double-work: if client times out before server picks up (perhaps it is busy serving another client and isn't `blpop`-ing), remove the task from queue as we exit; the client is then responsible for retries.
- Add a configurable timeout to the server, either as an arg or as a global. We were hitting instances in JRuby where Redis#blpop will stall out and block forever, despite items being put in queue; this ensures that we can configure around the issue.
- use `send` instead of routing everything through `method_missing`; I still provide the latter, but it feels a bit too "magic" to use it. This is a personal style thing, but it falls inline with most of the ruby community.
- route `respond_to?` to the remote object
- include backtrace with the remote exception, and explicitly pass the exception.to_s since not everything can pass through MultiJson.dump (Or JSON.encode) safely
