### PR TITLE
Ruby: MultiJson is now optional.

### DIFF
--- a/ruby/lib/redisrpc.rb
+++ b/ruby/lib/redisrpc.rb
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path('../redisrpc/version',__FILE__)
-require 'multi_json'
+require File.expand_path('../redisrpc/multi_json',__FILE__)
 
 require 'redis'
 

--- a/ruby/lib/redisrpc/multi_json.rb
+++ b/ruby/lib/redisrpc/multi_json.rb
@@ -1,0 +1,61 @@
+# Copyright (C) 2012.  Nathan Farrington <nfarring@gmail.com>
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Try to require multi_json for better performance. If multi_json is not found,
+# define the MultiJson module using Ruby's JSON implementation. Note that this
+# code is adapted from the multi_json project.
+begin
+  require 'multi_json'
+rescue LoadError
+  # Copyright (c) 2010 Michael Bleigh, Josh Kalderimis, Erik Michaels-Ober, and
+  # Intridea, Inc.
+  #
+  # Permission is hereby granted, free of charge, to any person obtaining a
+  # copy of this software and associated documentation files (the "Software"),
+  # to deal in the Software without restriction, including without limitation
+  # the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  # and/or sell copies of the Software, and to permit persons to whom the
+  # Software is furnished to do so, subject to the following conditions:
+  #
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  #
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  # DEALINGS IN THE SOFTWARE.
+  module MultiJson
+    require 'json'
+    class << self
+      def load(string, options={})
+        string = string.read if string.respond_to?(:read)
+        ::JSON.parse(string, :symbolize_names => options[:symbolize_keys])
+      end
+      def dump(object, options={})
+        object.to_json(process_options(options))
+      end
+    protected
+      def process_options(options={})
+        return options if options.empty?
+        opts = {}
+        opts.merge!(JSON::PRETTY_STATE_PROTOTYPE.to_h) if options.delete(:pretty)
+        opts.merge!(options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch makes the MultiJson Ruby gem optional. If MultiJson cannot be
found, it will be defined as a wrapper around the Ruby Json module.
