### PR TITLE
refactor ruby's server to be able to listen to multiple queues

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redisrpc (0.3.4)
+    redisrpc (0.3.5)
       multi_json (~> 1.3)
       redis
 


### PR DESCRIPTION
This patch is 100% backwards-compatible; it provides a new (preferred) way of creating a `Redis::RPC::Server` instance that allows it to listen on multiple queues. This is especially useful if you have multiple queues that tend to get activity in bursts, since this allows _any_ available server instance to respond to _any_ request to get through the burst, without any mid-process reconfiguring. 
